### PR TITLE
chore: configure workflows for gh_token readonly

### DIFF
--- a/.github/workflows/fill-gh-draft-release.yml
+++ b/.github/workflows/fill-gh-draft-release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  # To create or update releases
+  # https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-contents
+  contents: write
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,3 +14,5 @@
  * limitations under the License.
  */
 export * from './mxgraph-sketch';
+
+// fake change for testing

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,5 +14,3 @@
  * limitations under the License.
  */
 export * from './mxgraph-sketch';
-
-// fake change for testing


### PR DESCRIPTION
Release Drafter workflow configuration tested in https://github.com/process-analytics/github-actions-playground/issues/30

covers #86