### PR TITLE
ci: build with Node 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 16.x
       - name: Verify node, npm version
         run: |
           node --version


### PR DESCRIPTION
Node 12 is no longer available in the macos-14 runner.